### PR TITLE
[h4113] disable keymaster and keystore since we don't need them currently and they are not easily fixable. JB#42770

### DIFF
--- a/sparse/usr/libexec/droid-hybris/system/etc/init/android.hardware.keymaster@3.0-service-qti.rc
+++ b/sparse/usr/libexec/droid-hybris/system/etc/init/android.hardware.keymaster@3.0-service-qti.rc
@@ -1,0 +1,6 @@
+service keymaster-3-0 /odm/bin/hw/android.hardware.keymaster@3.0-service-qti_HYBRIS_DISABLED
+    class early_hal
+    user system
+    group system drmrpc
+    disabled
+

--- a/sparse/usr/libexec/droid-hybris/system/etc/init/keystore.rc
+++ b/sparse/usr/libexec/droid-hybris/system/etc/init/keystore.rc
@@ -1,0 +1,7 @@
+service keystore /system/bin/keystore /data/misc/keystore_HYBRIS_DISABLED
+    class main
+    user keystore
+    group keystore drmrpc readproc
+    writepid /dev/cpuset/foreground/tasks
+    disabled
+


### PR DESCRIPTION
They depend on the android security patch level of boot.img and system.img to match apparently.

But since neither boot.img nor system.img are android partitions with sailfish this is problematic.

keystore is only disabled because it would spam logs with waiting for keymaster.