### PR TITLE
[ks] Set $DEVICE during image generation. Fixes MER#1960

### DIFF
--- a/kickstart/pack/h4113/hybris
+++ b/kickstart/pack/h4113/hybris
@@ -145,6 +145,11 @@ mv ${FILES} ${RELEASENAME}/
 
 # Calculate md5sums of files included to the archive
 cd ${RELEASENAME}
+
+# Set $DEVICE in flash scripts
+sed -e "s/\@DEVICE\@/@DEVICE@/g" -i flash.sh
+sed -e "s/\@DEVICE\@/@DEVICE@/g" -i flash-on-windows.bat
+
 md5sum * > $MD5SUMFILE
 cd ..
 

--- a/sparse/boot/flash-on-windows.bat
+++ b/sparse/boot/flash-on-windows.bat
@@ -61,7 +61,7 @@ exit /b 1
 for %%d in ( %serialnumbers% ) do (
   set fastbootcmd=%fastbootcmd_no_devic% -s %%d
   @call :getvar product
-  findstr /R /C:"product: h4113" %tmpflashfile% >NUL 2>NUL
+  findstr /R /C:"product: @DEVICE@" %tmpflashfile% >NUL 2>NUL
   if not errorlevel 1 (
     call :new_product_found %%d
   )

--- a/sparse/boot/flash-on-windows.bat
+++ b/sparse/boot/flash-on-windows.bat
@@ -31,7 +31,7 @@ call :sleep 3
 @call :md5sum flash-on-windows.bat
 
 set fastbootcmd_no_device=fastboot.exe
-set current_device=
+set products=
 
 echo(
 echo Searching a compatible device...
@@ -58,20 +58,16 @@ exit /b 1
 
 :no_error_serialnumbers
 
+for %%d in ( %serialnumbers% ) do (
+  set fastbootcmd=%fastbootcmd_no_devic% -s %%d
+  @call :getvar product
+  findstr /R /C:"product: h4113" %tmpflashfile% >NUL 2>NUL
+  if not errorlevel 1 (
+    call :new_product_found %%d
+  )
+)
 
-if "%serialnumbers%" == "%serialnumbers: =%" GOTO no_multiple_serialnumbers
-
-echo(
-echo It seems that there are multiple compatible devices connected in fastboot mode.
-echo Make sure only the device that you intend to flash is connected.
-pause
-exit /b 1
-
-:no_multiple_serialnumbers
-
-set current_device=%serialnumbers%
-
-if not [%current_device%] == [] GOTO no_error_product
+if not [%products] == [] goto no_error_product 
 
 echo(
 echo The DEVICE this flashing script is meant for WAS NOT FOUND!
@@ -83,8 +79,19 @@ exit /b 1
 
 :no_error_product
 
+if "%products" == "%products: =%" GOTO no_multiple_products
+
+echo(
+echo It seems that there are multiple compatible devices connected in fastboot mode.
+echo Make sure only the device that you intend to flash is connected.
+pause
+exit /b 1
+
+
+:no_multiple_products
+
 :: Now we know which device we need to flash
-set fastbootcmd=%fastbootcmd_no_device% -s %current_device%
+set fastbootcmd=%fastbootcmd_no_device% -s %products%
 
 :: Check that device has been unlocked
 @call :getvar secure
@@ -178,6 +185,15 @@ if "%serialnumbers%" == "" (
 set serialnumbers=%serialno%
 ) else (
 set "serialnumbers=%serialno% %serialnumbers%"
+)
+@exit /b 0
+
+:new_product_found
+set product=%1
+if "%products" == "" (
+set products=%product%
+) else (
+set "products=%product %products"
 )
 @exit /b 0
 

--- a/sparse/boot/flash.sh
+++ b/sparse/boot/flash.sh
@@ -104,7 +104,7 @@ count=0
 for SERIALNO in $FASTBOOT_DEVICES; do
   PRODUCT=$($FASTBOOTCMD_NO_DEVICE -s $SERIALNO getvar product 2>&1 | head -n1 | cut -d ' ' -f2)
 
-  if [ ! -z "$(echo $PRODUCT | grep -e "H3113" -e "H4113")" ]; then
+  if [ ! -z "$(echo $PRODUCT | grep -e "@DEVICE@")" ]; then
     SERIALNUMBERS="$SERIALNO $SERIALNUMBERS"
     ((++count))
   fi


### PR DESCRIPTION
This avoids having to grep for multiple devices in flash.sh or flash-on-windows.bat
Requires $DEVICE to be added to the tokenmap.