### PR TITLE
Ensure we boot correctly even from slot b. Fixes JB#43761

### DIFF
--- a/sparse/boot/flash-on-windows.bat
+++ b/sparse/boot/flash-on-windows.bat
@@ -146,12 +146,13 @@ exit /b 1
 :: happens when flashing is done.
 @echo on
 
-@call :fastboot flash boot hybris-boot.img
+@call :fastboot flash boot_a hybris-boot.img
+@call :fastboot flash boot_b hybris-boot.img
 @call :fastboot flash system_b fimage.img001
 @call :fastboot flash userdata sailfish.img001
 @call :fastboot flash vendor_a vendor.img001
 @call :fastboot flash vendor_b vendor.img001
-@call :fastboot flash oem %blobfilename%
+@call :fastboot flash oem_a %blobfilename%
 
 :: NOTE: Do not reboot here as the battery might not be in the device
 :: and in such situation we should not reboot the device.

--- a/sparse/boot/flash.sh
+++ b/sparse/boot/flash.sh
@@ -140,6 +140,7 @@ fi
 
 IMAGES=(
 "boot_a ${SAILFISH_IMAGE_PATH}hybris-boot.img"
+"boot_b ${SAILFISH_IMAGE_PATH}hybris-boot.img"
 "userdata ${SAILFISH_IMAGE_PATH}sailfish.img001"
 "system_b ${SAILFISH_IMAGE_PATH}fimage.img001"
 "vendor_a ${SAILFISH_IMAGE_PATH}vendor.img001"
@@ -207,7 +208,7 @@ for IMAGE in "${IMAGES[@]}"; do
 done
 
 echo "Flashing oem partition.."
-$FLASHCMD oem $BLOBS
+$FLASHCMD oem_a $BLOBS
 
 echo
 echo "Flashing completed."

--- a/sparse/var/lib/platform-updates/flash-bootimg.sh
+++ b/sparse/var/lib/platform-updates/flash-bootimg.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 
 /usr/sbin/flash-partition boot_a /boot/hybris-boot.img
+/usr/sbin/flash-partition boot_b /boot/hybris-boot.img
 


### PR DESCRIPTION
Quite a few users reported their freshly flashed XA2s to bootloop, and our quick investigation [1] shown that they all are on the slot B of the partitions.

[1] https://together.jolla.com/question/192632/xa2-h4113-bootloops-after-flashing-trial-3008/?answer=192655#post-id-192655