### PR TITLE
[xa2] Disable unneeded wificond service. JB#44057, JB#43903

### DIFF
--- a/sparse/usr/libexec/droid-hybris/system/etc/init/wificond.rc
+++ b/sparse/usr/libexec/droid-hybris/system/etc/init/wificond.rc
@@ -1,0 +1,4 @@
+service wificond /system/bin/wificond_HYBRIS_DISABLED
+    class main
+    user wifi
+    group wifi net_raw net_admin


### PR DESCRIPTION
Not needed on device and causes quite much messages in logcat.