### PR TITLE
WIP: sw-binaries: point to v16 instead of latest (v17)

### DIFF
--- a/sparse/boot/flash-on-windows.bat
+++ b/sparse/boot/flash-on-windows.bat
@@ -6,7 +6,7 @@
 set tmpflashfile=tmpfile.txt
 set emmawebsite=https://developer.sony.com/develop/open-devices/get-started/flash-tool/download-flash-tool/
 set unlockwebsite=https://developer.sony.com/develop/open-devices/get-started/unlock-bootloader/
-set oemblobwebsite=https://developer.sony.com/file/download/software-binaries-for-aosp-oreo-android-8-1-kernel-4-4-nile/
+set oemblobwebsite=https://developer.sony.com/file/download/software-binaries-for-aosp-oreo-android-8-1-kernel-4-4-nile-v16/
 set fastbootkillretval=0
 set serialnumbers=
 

--- a/sparse/boot/flash.sh
+++ b/sparse/boot/flash.sh
@@ -194,7 +194,7 @@ done
 if [ -z $BLOBS ]; then
   echo; echo The Sony Vendor partition image was not found in the current directory. Please
   echo download it from
-  echo https://developer.sony.com/file/download/software-binaries-for-aosp-oreo-android-8-1-kernel-4-4-nile/
+  echo https://developer.sony.com/file/download/software-binaries-for-aosp-oreo-android-8-1-kernel-4-4-nile-v16/
   echo and unzip it into this directory.
   echo
   exit 1

--- a/sparse/boot/flashing-README.txt
+++ b/sparse/boot/flashing-README.txt
@@ -69,7 +69,7 @@ partition image, ready to flash to your device.
 
 The Sony binary image for the Xperia™ XA2 can be found here:
 
-https://developer.sony.com/file/download/software-binaries-for-aosp-oreo-android-8-1-kernel-4-4-nile/
+https://developer.sony.com/file/download/software-binaries-for-aosp-oreo-android-8-1-kernel-4-4-nile-v16/
 
 The image will be compressed as a zip file. Once downloaded, extract the image 
 file from the zip and place it with the other Sailfish X files. It will be 


### PR DESCRIPTION
we might not need this for 3.0.2 and up, just keeping for 3.0.1 reference