### PR TITLE
sw-binaries: strict version check and make links future-proof

### DIFF
--- a/sparse/boot/flash-on-windows.bat
+++ b/sparse/boot/flash-on-windows.bat
@@ -6,7 +6,8 @@
 set tmpflashfile=tmpfile.txt
 set emmawebsite=https://developer.sony.com/develop/open-devices/get-started/flash-tool/download-flash-tool/
 set unlockwebsite=https://developer.sony.com/develop/open-devices/get-started/unlock-bootloader/
-set oemblobwebsite=https://developer.sony.com/file/download/software-binaries-for-aosp-oreo-android-8-1-kernel-4-4-nile/
+set oemblobversion=v17
+set oemblobwebsite=https://developer.sony.com/develop/open-devices/downloads/software-binaries/
 set fastbootkillretval=0
 set serialnumbers=
 
@@ -111,7 +112,7 @@ del %tmpflashfile% >NUL 2>NUL
 setlocal EnableDelayedExpansion
 
 :: Find the blob image. Make sure there's only one.
-for /r %%f in (*_nile.img) do (
+for /r %%f in (*_%oemblobversion%_nile.img) do (
 if not defined blobfilename (
 :: Take only the filename and strip out the path which otherwise is there.
 :: This is to make sure that we do not face issues later with e.g. spaces in the path etc.
@@ -119,7 +120,7 @@ set blobfilename=%%~nxf
 ) else (
 echo(
 echo More than one Sony Vendor image was found in this directory.
-echo Please remove any additional files ^(*_nile.img^).
+echo Please remove any additional files ^(*_%oemblobversion%_nile.img^).
 echo(
 exit /b 1
 )
@@ -134,6 +135,10 @@ echo(
 echo The Sony Vendor partition image was not found in the current
 echo directory. Please download it from %oemblobwebsite%
 echo and unzip it into this directory.
+echo(
+echo Ensure you download %oemblobversion% of the image, which can be found under:
+echo "Software binaries for AOSP Oreo (Android 8.1) - Kernel 4.4 - Nile"
+echo either (latest) or (%oemblobversion%)
 echo(
 echo Press enter to open the browser with the webpage.
 echo(

--- a/sparse/boot/flash.sh
+++ b/sparse/boot/flash.sh
@@ -182,7 +182,8 @@ if [ -z ${BLOB_BIN_PATH} ]; then
 fi
 
 BLOBS=""
-for b in $(ls -1 ${BLOB_BIN_PATH}/*_nile.img 2>/dev/null); do
+BLOBS_VERSION=v17
+for b in $(ls -1 ${BLOB_BIN_PATH}/*_${BLOBS_VERSION}_nile.img 2>/dev/null); do
   if [ -n "$BLOBS" ]; then
    echo; echo "More than one Sony Vendor image was found. Please remove any additional files."
    echo
@@ -194,7 +195,10 @@ done
 if [ -z $BLOBS ]; then
   echo; echo The Sony Vendor partition image was not found in the current directory. Please
   echo download it from
-  echo https://developer.sony.com/file/download/software-binaries-for-aosp-oreo-android-8-1-kernel-4-4-nile/
+  echo https://developer.sony.com/develop/open-devices/downloads/software-binaries/
+  echo Ensure you download $BLOBS_VERSION of the image, which can be found under:
+  echo '"Software binaries for AOSP Oreo (Android 8.1) - Kernel 4.4 - Nile"'
+  echo "either (latest) or ($BLOBS_VERSION)"
   echo and unzip it into this directory.
   echo
   exit 1

--- a/sparse/boot/flashing-README.txt
+++ b/sparse/boot/flashing-README.txt
@@ -67,13 +67,10 @@ license agreement.
 For convenience, these components have already been packaged into their own
 partition image, ready to flash to your device. 
 
-The Sony binary image for the Xperia™ XA2 can be found here:
+During the flashing process you will be asked to download the required image.
+It will be compressed as a zip file. Once downloaded, extract the image file
+from the zip and place it with the other Sailfish X files.
 
-https://developer.sony.com/file/download/software-binaries-for-aosp-oreo-android-8-1-kernel-4-4-nile/
-
-The image will be compressed as a zip file. Once downloaded, extract the image 
-file from the zip and place it with the other Sailfish X files. It will be 
-detected and flashed to your device during flashing.
 
 = STEP 4 : FLASHING SAILFISH X TO YOUR XPERIA™ =
 


### PR DESCRIPTION
New versions of SW binaries might break functionality, let's enforce the check.

We can't hardcode versions into links, because (latest) does not have the
version yet in its URL. Will supply with generic link and ask user to choose.

This will need to go into 3.0.2 branch as well.