### PR TITLE
patterns: Remove udisk2 package from hw pattern.

### DIFF
--- a/patterns/jolla-hw-adaptation-discovery.yaml
+++ b/patterns/jolla-hw-adaptation-discovery.yaml
@@ -68,9 +68,6 @@ Requires:
 # For GPS
 - geoclue-provider-hybris
 
-# For devices with SD Card
-- udisks2
-
 # For FM radio on some QCOM devices
 #- qt5-qtmultimedia-plugin-mediaservice-irisradio
 #- jolla-mediaplayer-radio

--- a/patterns/jolla-hw-adaptation-pioneer.yaml
+++ b/patterns/jolla-hw-adaptation-pioneer.yaml
@@ -72,8 +72,5 @@ Requires:
 #- qt5-qtmultimedia-plugin-mediaservice-irisradio
 #- jolla-mediaplayer-radio
 
-# For devices with SD Card
-- udisks2
-
 Summary: Jolla HW Adaptation pioneer
 

--- a/patterns/jolla-hw-adaptation-voyager.yaml
+++ b/patterns/jolla-hw-adaptation-voyager.yaml
@@ -72,8 +72,5 @@ Requires:
 #- qt5-qtmultimedia-plugin-mediaservice-irisradio
 #- jolla-mediaplayer-radio
 
-# For devices with SD Card
-- udisks2
-
 Summary: Jolla HW Adaptation voyager
 


### PR DESCRIPTION
[patterns] Remove udisk2 package from hw pattern. JB#46513

Udisk2 is dependency for patterns-sailfish-mw meta package.

Signed-off-by: Matti Kosola <matti.kosola@jolla.com>