### PR TITLE
configs: Symlink to directory workaround.

### DIFF
--- a/rpm/droid-config-h3113.spec
+++ b/rpm/droid-config-h3113.spec
@@ -6,3 +6,10 @@
 
 %include droid-config-common.inc
 %include droid-configs-device/droid-configs.inc
+
+%pretrans -p <lua>
+path = "/lib/firmware"
+st = posix.stat(path)
+if st and st.type == "link" then
+  os.remove(path)
+end

--- a/rpm/droid-config-h3213.spec
+++ b/rpm/droid-config-h3213.spec
@@ -6,3 +6,10 @@
 
 %include droid-config-common.inc
 %include droid-configs-device/droid-configs.inc
+
+%pretrans -p <lua>
+path = "/lib/firmware"
+st = posix.stat(path)
+if st and st.type == "link" then
+  os.remove(path)
+end

--- a/rpm/droid-config-h3413.spec
+++ b/rpm/droid-config-h3413.spec
@@ -6,3 +6,10 @@
 
 %include droid-config-common.inc
 %include droid-configs-device/droid-configs.inc
+
+%pretrans -p <lua>
+path = "/lib/firmware"
+st = posix.stat(path)
+if st and st.type == "link" then
+  os.remove(path)
+end

--- a/rpm/droid-config-h4113.spec
+++ b/rpm/droid-config-h4113.spec
@@ -6,3 +6,10 @@
 
 %include droid-config-common.inc
 %include droid-configs-device/droid-configs.inc
+
+%pretrans -p <lua>
+path = "/lib/firmware"
+st = posix.stat(path)
+if st and st.type == "link" then
+  os.remove(path)
+end

--- a/rpm/droid-config-h4213.spec
+++ b/rpm/droid-config-h4213.spec
@@ -6,3 +6,10 @@
 
 %include droid-config-common.inc
 %include droid-configs-device/droid-configs.inc
+
+%pretrans -p <lua>
+path = "/lib/firmware"
+st = posix.stat(path)
+if st and st.type == "link" then
+  os.remove(path)
+end

--- a/rpm/droid-config-h4413.spec
+++ b/rpm/droid-config-h4413.spec
@@ -6,3 +6,10 @@
 
 %include droid-config-common.inc
 %include droid-configs-device/droid-configs.inc
+
+%pretrans -p <lua>
+path = "/lib/firmware"
+st = posix.stat(path)
+if st and st.type == "link" then
+  os.remove(path)
+end


### PR DESCRIPTION
Due to a known limitation with RPM, it is not possible to replace
a directory with any kind of file or symlink, nor is it possible
to replace a symlink to a directory with a directory, without RPM
producing file conflict errors while trying to install the package.

See: https://fedoraproject.org/wiki/Packaging:Directory_Replacement