### PR TITLE
Lookup operator names in MBPI

### DIFF
--- a/sparse/etc/ofono/ril_subscription.conf
+++ b/sparse/etc/ofono/ril_subscription.conf
@@ -10,6 +10,7 @@ SetRadioCapability=off
 emptyPinQuery=false
 radioPowerCycle=false
 confirmRadioPowerOn=false
+replaceStrangeOperatorNames=true
 
 [ril_0]
 transport=binder:name=slot1


### PR DESCRIPTION
This sort of fixes the problem with all operators in the scan having the same name.