### PR TITLE
Nuke yaml patterns

### DIFF
--- a/delete_pattern_h3113.list
+++ b/delete_pattern_h3113.list
@@ -1,5 +1,0 @@
-/usr/share/package-groups/jolla-configuration-h3213.xml
-/usr/share/package-groups/jolla-configuration-h3413.xml
-/usr/share/package-groups/jolla-configuration-h4113.xml
-/usr/share/package-groups/jolla-configuration-h4213.xml
-/usr/share/package-groups/jolla-configuration-h4413.xml

--- a/delete_pattern_h3213.list
+++ b/delete_pattern_h3213.list
@@ -1,5 +1,0 @@
-/usr/share/package-groups/jolla-configuration-h3113.xml
-/usr/share/package-groups/jolla-configuration-h3413.xml
-/usr/share/package-groups/jolla-configuration-h4113.xml
-/usr/share/package-groups/jolla-configuration-h4213.xml
-/usr/share/package-groups/jolla-configuration-h4413.xml

--- a/delete_pattern_h3413.list
+++ b/delete_pattern_h3413.list
@@ -1,5 +1,0 @@
-/usr/share/package-groups/jolla-configuration-h3113.xml
-/usr/share/package-groups/jolla-configuration-h3213.xml
-/usr/share/package-groups/jolla-configuration-h4113.xml
-/usr/share/package-groups/jolla-configuration-h4213.xml
-/usr/share/package-groups/jolla-configuration-h4413.xml

--- a/delete_pattern_h4113.list
+++ b/delete_pattern_h4113.list
@@ -1,5 +1,0 @@
-/usr/share/package-groups/jolla-configuration-h3113.xml
-/usr/share/package-groups/jolla-configuration-h3213.xml
-/usr/share/package-groups/jolla-configuration-h3413.xml
-/usr/share/package-groups/jolla-configuration-h4213.xml
-/usr/share/package-groups/jolla-configuration-h4413.xml

--- a/delete_pattern_h4213.list
+++ b/delete_pattern_h4213.list
@@ -1,5 +1,0 @@
-/usr/share/package-groups/jolla-configuration-h3113.xml
-/usr/share/package-groups/jolla-configuration-h3213.xml
-/usr/share/package-groups/jolla-configuration-h3413.xml
-/usr/share/package-groups/jolla-configuration-h4113.xml
-/usr/share/package-groups/jolla-configuration-h4413.xml

--- a/delete_pattern_h4413.list
+++ b/delete_pattern_h4413.list
@@ -1,5 +1,0 @@
-/usr/share/package-groups/jolla-configuration-h3113.xml
-/usr/share/package-groups/jolla-configuration-h3213.xml
-/usr/share/package-groups/jolla-configuration-h3413.xml
-/usr/share/package-groups/jolla-configuration-h4113.xml
-/usr/share/package-groups/jolla-configuration-h4213.xml

--- a/patterns/jolla-configuration-h3113.yaml
+++ b/patterns/jolla-configuration-h3113.yaml
@@ -1,7 +1,0 @@
-Description: Pattern with packages for h3113 configurations
-Name: jolla-configuration-h3113
-Requires:
-- patterns-sailfish-device-configuration-h3113
-
-Summary: Jolla Configuration h3113
-

--- a/patterns/jolla-configuration-h3213.yaml
+++ b/patterns/jolla-configuration-h3213.yaml
@@ -1,6 +1,0 @@
-Description: Pattern with packages for h3213 configurations
-Name: jolla-configuration-h3213
-Requires:
-- patterns-sailfish-device-configuration-h3213
-
-Summary: Jolla Configuration h3213

--- a/patterns/jolla-configuration-h3413.yaml
+++ b/patterns/jolla-configuration-h3413.yaml
@@ -1,7 +1,0 @@
-Description: Pattern with packages for h3413 configurations
-Name: jolla-configuration-h3413
-Requires:
-- patterns-sailfish-device-configuration-h3413
-
-Summary: Jolla Configuration h3413
-

--- a/patterns/jolla-configuration-h4113.yaml
+++ b/patterns/jolla-configuration-h4113.yaml
@@ -1,7 +1,0 @@
-Description: Pattern with packages for h4113 configurations
-Name: jolla-configuration-h4113
-Requires:
-- patterns-sailfish-device-configuration-h4113
-
-Summary: Jolla Configuration h4113
-

--- a/patterns/jolla-configuration-h4213.yaml
+++ b/patterns/jolla-configuration-h4213.yaml
@@ -1,7 +1,0 @@
-Description: Pattern with packages for h4213 configurations
-Name: jolla-configuration-h4213
-Requires:
-- patterns-sailfish-device-configuration-h4213
-
-Summary: Jolla Configuration h4213
-

--- a/patterns/jolla-configuration-h4413.yaml
+++ b/patterns/jolla-configuration-h4413.yaml
@@ -1,7 +1,0 @@
-Description: Pattern with packages for h4413 configurations
-Name: jolla-configuration-h4413
-Requires:
-- patterns-sailfish-device-configuration-h4413
-
-Summary: Jolla Configuration h4413
-


### PR DESCRIPTION
[patterns] remove sailfish-porter-tools
[patterns] remove yaml leftovers

Update submodule
[sparse] support vendor-specific versioned sparse
[sparse] support sparse for adaptations that package own /system