### PR TITLE
patterns: Require sailfish-fpd

### DIFF
--- a/patterns/patterns-sailfish-device-adaptation-discovery.inc
+++ b/patterns/patterns-sailfish-device-adaptation-discovery.inc
@@ -55,6 +55,7 @@ Requires: rfkill
 
 # enable device lock and allow to select untrusted software
 Requires: sailfish-devicelock-fpd
+Requires: sailfish-fpd
 
 # Enable home encryption
 Requires: sailfish-device-encryption

--- a/patterns/patterns-sailfish-device-adaptation-pioneer.inc
+++ b/patterns/patterns-sailfish-device-adaptation-pioneer.inc
@@ -55,6 +55,7 @@ Requires: rfkill
 
 # enable device lock and allow to select untrusted software
 Requires: sailfish-devicelock-fpd
+Requires: sailfish-fpd
 
 # Enable home encryption
 Requires: sailfish-device-encryption

--- a/patterns/patterns-sailfish-device-adaptation-voyager.inc
+++ b/patterns/patterns-sailfish-device-adaptation-voyager.inc
@@ -55,6 +55,7 @@ Requires: rfkill
 
 # enable device lock and allow to select untrusted software
 Requires: sailfish-devicelock-fpd
+Requires: sailfish-fpd
 
 # Enable home encryption
 Requires: sailfish-device-encryption


### PR DESCRIPTION
As sailfish-devicelock-fpd no longer explicitly requires sailfish-fpd, it needs to be pulled in via patterns.

[patterns] Require sailfish-fpd. JB#62474