### PR TITLE
Set WPA3 support to mixed in ConnMan config

### DIFF
--- a/sparse/etc/connman/main.conf.d/10-nile.conf
+++ b/sparse/etc/connman/main.conf.d/10-nile.conf
@@ -1,0 +1,2 @@
+[General]
+WifiWPA3Support = mixed


### PR DESCRIPTION
This device's driver reports having WPA3 SAE support but either driver or firmware lacks something for establishing a connection. Networks seem to work with mixed mode with WPA3, thus, settings support to mixed.